### PR TITLE
chore: rename verify fn to is_valid

### DIFF
--- a/src/public/ec/mod.rs
+++ b/src/public/ec/mod.rs
@@ -450,7 +450,7 @@ pub mod ecdsa {
             &self.bytes[..self.len]
         }
 
-        fn is_valid(&self) -> bool {
+        fn has_content(&self) -> bool {
             self.len != 0
         }
 
@@ -474,8 +474,8 @@ pub mod ecdsa {
             Ok(sig)
         }
 
-        fn verify(&self, key: &EcPubKey<C>, message: &[u8]) -> bool {
-            if !self.is_valid() {
+        fn is_valid(&self, key: &EcPubKey<C>, message: &[u8]) -> bool {
+            if !self.has_content() {
                 // see comment on EcdsaSignature::len for why we do this
                 return false;
             }
@@ -532,8 +532,8 @@ pub mod ecdsa {
         fn test_invalid_signature() {
             fn test_is_invalid(sig: &EcdsaSignature<P256, Sha256>) {
                 assert_eq!(sig.len, 0);
-                assert!(!sig.is_valid());
-                assert!(!sig.verify(&EcPrivKey::<P256>::generate().unwrap().public(), &[],));
+                assert!(!sig.has_content());
+                assert!(!sig.is_valid(&EcPrivKey::<P256>::generate().unwrap().public(), &[],));
             }
             test_is_invalid(&EcdsaSignature::from_bytes(&[0; MAX_SIGNATURE_LEN + 1]));
             test_is_invalid(&EcdsaSignature::from_bytes(&[]));
@@ -593,7 +593,7 @@ mod tests {
             {
                 let sig = EcdsaSignature::<C, Sha256>::sign(&privkey, MESSAGE).unwrap();
                 assert!(
-                    EcdsaSignature::<C, Sha256>::from_bytes(sig.bytes()).verify(&pubkey, MESSAGE)
+                    EcdsaSignature::<C, Sha256>::from_bytes(sig.bytes()).is_valid(&pubkey, MESSAGE)
                 )
             }
 

--- a/src/public/ed25519.rs
+++ b/src/public/ed25519.rs
@@ -166,7 +166,7 @@ impl Signature for Ed25519Signature {
         Ok(Ed25519Signature::sign_ed25519(key, message))
     }
 
-    fn verify(&self, key: &Ed25519PubKey, message: &[u8]) -> bool {
+    fn is_valid(&self, key: &Ed25519PubKey, message: &[u8]) -> bool {
         ed25519_verify(message, &self.sig, &key.key)
     }
 }

--- a/src/public/mod.rs
+++ b/src/public/mod.rs
@@ -22,16 +22,16 @@ pub trait PublicKey: Sealed + Sized {
 
     /// Verifies a message with this public key.
     ///
-    /// `verify` verifies that a message was signed by the private key
+    /// `is_valid` verifies that a message was signed by the private key
     /// corresponding to this public key. It is equivalent to
-    /// `signature.verify(self, message)`.
+    /// `signature.is_valid(self, message)`.
     #[must_use]
-    fn verify<S: Signature<PrivateKey = Self::Private>>(
+    fn is_valid<S: Signature<PrivateKey = Self::Private>>(
         &self,
         message: &[u8],
         signature: &S,
     ) -> bool {
-        signature.verify(self, message)
+        signature.is_valid(self, message)
     }
 }
 
@@ -175,10 +175,10 @@ pub trait Signature: Sealed + Sized {
     ///
     /// The input to this function is always a message, never a digest. If a
     /// signature scheme calls for hashing a message and signing the hash
-    /// digest, `verify` is responsible for both hashing and verifying the
+    /// digest, `is_valid` is responsible for both hashing and verifying the
     /// digest.
     #[must_use]
-    fn verify(&self, key: &<Self::PrivateKey as PrivateKey>::Public, message: &[u8]) -> bool;
+    fn is_valid(&self, key: &<Self::PrivateKey as PrivateKey>::Public, message: &[u8]) -> bool;
 }
 
 mod inner {
@@ -238,17 +238,17 @@ mod testutil {
             bytes_from_sig: G,
         ) -> S {
             let sig = S::sign(key, message).unwrap();
-            assert!(sig.verify(&key.public(), message));
+            assert!(sig.is_valid(&key.public(), message));
             // Make sure the PrivateKey::sign and PublicKey::verify convenience
             // functions also work.
             let sig = key.sign::<S>(message).unwrap();
-            assert!(key.public().verify(message, &sig));
+            assert!(key.public().is_valid(message, &sig));
             let sig2 = S::sign(&key, bytes_from_sig(&sig)).unwrap();
-            assert!(!sig2.verify(&key.public(), message));
+            assert!(!sig2.is_valid(&key.public(), message));
             // Make sure the PrivateKey::sign and PublicKey::verify convenience
             // functions also work.
             let sig2 = key.sign::<S>(bytes_from_sig(&sig)).unwrap();
-            assert!(!key.public().verify(message, &sig2));
+            assert!(!key.public().is_valid(message, &sig2));
             sig_from_bytes(bytes_from_sig(&sig))
         }
 


### PR DESCRIPTION
This PR addresses #16, renaming `Signature::verify` to `Signature::is_valid` to make it more clear to the user.